### PR TITLE
Fixed an issue with the user restriction in the Paginator

### DIFF
--- a/InteractivityAddon/Pagination/Paginator.cs
+++ b/InteractivityAddon/Pagination/Paginator.cs
@@ -70,7 +70,7 @@ namespace Interactivity.Pagination
         #region Methods
         internal async Task<bool> HandleReactionAsync(BaseSocketClient client, SocketReaction reaction)
         {
-            bool valid = await RunChecksAsync(client, reaction).ConfigureAwait(false) && (IsUserRestricted || Users.Any(x => x.Id == reaction.UserId));
+            bool valid = await RunChecksAsync(client, reaction).ConfigureAwait(false) && (!IsUserRestricted || Users.Any(x => x.Id == reaction.UserId));
 
             if (Deletion.HasFlag(DeletionOptions.Invalids) && !valid)
             {


### PR DESCRIPTION
The paginator did allow anyone to navigate through pages.
This simple change fixes the boolean algebra so it correctly disallows other people to use the pages.