### PR TITLE
Remove forced overwrite of parameterized IUserMessage

### DIFF
--- a/InteractivityAddon/InteractivityService.cs
+++ b/InteractivityAddon/InteractivityService.cs
@@ -395,11 +395,6 @@ namespace Interactivity
                 {
                     throw new ArgumentException("Message author not current user!");
                 }
-
-                await message.ModifyAsync(x =>
-                {
-                    x.Embed = selection.SelectionEmbed;
-                }).ConfigureAwait(false);
             }
             else
             {
@@ -493,11 +488,6 @@ namespace Interactivity
                 {
                     throw new ArgumentException("Message author not current user!");
                 }
-
-                await message.ModifyAsync(x =>
-                {
-                    x.Embed = selection.SelectionEmbed;
-                }).ConfigureAwait(false);
             }
             else
             {


### PR DESCRIPTION
More details about why I made this PR can be found in #8. This change has been tested to do what that feature request lays out.

Before:
![](https://i.imgur.com/GTydi0u.png)

After:
![](https://i.imgur.com/Q4Vxlw7.png)

Code used to test and get these results:
```cs
[Command("reactionselection")]
public async Task ExampleReactionSelectionAsync()
{
    var builder = new ReactionSelectionBuilder<string>()
                    .WithValues("Hi", "How", "Hey", "Huh?!")
                    .WithEmotes(new Emoji("💵"), new Emoji("🍭"), new Emoji("😩"), new Emoji("💠"))
                    .WithUsers(Context.User)
                    .WithDeletion(DeletionOptions.AfterCapturedContext | DeletionOptions.Invalids)
                    .WithEnableDefaultSelectionDescription(false);

    var embed = new EmbedBuilder()
                .WithDescription("Test 123")
                .WithColor(Color.Blue)
                .Build();

    var restUserMessage = await Context.Channel.SendMessageAsync(embed: embed);
    
    var result = await Interactivity.SendSelectionAsync(builder.Build(), Context.Channel, TimeSpan.FromSeconds(50), restUserMessage);

    if (result.IsSuccess == true)
    {
        await Context.Channel.SendMessageAsync(result.Value.ToString());
    }
}
```
