### PR TITLE
Fix Selections from throwing exceptions in dms

### DIFF
--- a/InteractivityAddon/InteractivityAddon.csproj
+++ b/InteractivityAddon/InteractivityAddon.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Discord.InteractivityAddon</AssemblyName>
     <RootNamespace>Interactivity</RootNamespace>
-    <Version>2.4.0-dev-20210218.1</Version>
+    <Version>2.4.0-dev-20210307.1</Version>
     <RepositoryUrl>https://github.com/Playwo/Discord.InteractivityAddon</RepositoryUrl>
     <AssemblyVersion>2.4.0</AssemblyVersion>
     <FileVersion>2.4.0</FileVersion>

--- a/InteractivityAddon/Selection/Reaction/ReactionSelection.cs
+++ b/InteractivityAddon/Selection/Reaction/ReactionSelection.cs
@@ -83,7 +83,10 @@ namespace Interactivity.Selection
 
         protected override async Task CloseMessageAsync(IUserMessage message, InteractivityResult<TValue> result)
         {
-            await message.RemoveAllReactionsAsync();
+            //the remove all reactions endpoint requires the user to have the manage messages permission
+            //the user wont have this in a DM channel and calling this will throw HttpExceptions
+            if (message.Channel is not IDMChannel)
+                await message.RemoveAllReactionsAsync();
 
             if (result.IsCancelled && CancelledPage != null)
             {


### PR DESCRIPTION
# Summary
Currently, when using reaction selections in a DM the selection will be ignored.  This is because HttpExceptions are thrown that indicate missing permissions.  This occurs because the remove all reactions endpoint requires the user to have the manage messages permission and the user cant have this in a dm.

https://discord.com/developers/docs/resources/channel#delete-all-reactions 

## Fix
I simply just check if the message's channel is not a DM channel before removing the reactions.

## Unintended Side Effects
This fix introduces side effects where selections in DMs and guild channels will behave differently.  The DM selection's reactions will remain after the selection is complete while in the guild channel the reactions will be removed as intended.