### PR TITLE
Update Readme example to compare by user id

### DIFF
--- a/InteractivityAddon/InteractivityService.cs
+++ b/InteractivityAddon/InteractivityService.cs
@@ -329,7 +329,7 @@ namespace Interactivity
 
             if (message != null)
             {
-                if (message.Author != Client.CurrentUser)
+                if (message.Author.Id != Client.CurrentUser.Id)
                 {
                     throw new ArgumentException("Message author not current user!");
                 }
@@ -449,7 +449,7 @@ namespace Interactivity
 
             if (message != null)
             {
-                if (selection is ReactionSelection<TValue> && message.Author != Client.CurrentUser)
+                if (selection is ReactionSelection<TValue> && message.Author.Id != Client.CurrentUser.Id)
                 {
                     throw new ArgumentException("Cannot use message from different user!");
                 }
@@ -561,7 +561,7 @@ namespace Interactivity
 
             if (message != null)
             {
-                if (selection is MessageSelection<TValue> && message.Author != Client.CurrentUser)
+                if (selection is MessageSelection<TValue> && message.Author.Id != Client.CurrentUser.Id)
                 {
                     throw new ArgumentException("Cannot use message from different user!");
                 }
@@ -575,7 +575,7 @@ namespace Interactivity
 
             async Task CheckMessageAsync(SocketMessage m)
             {
-                if (m.Author == Client.CurrentUser)
+                if (m.Author.Id == Client.CurrentUser.Id)
                 {
                     return;
                 }
@@ -669,7 +669,7 @@ namespace Interactivity
 
             if (message != null)
             {
-                if (message.Author != Client.CurrentUser)
+                if (message.Author.Id != Client.CurrentUser.Id)
                 {
                     throw new ArgumentException("Message author not current user!");
                 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Inject the InteractivityService into your Module using DI instead. (Constructor 
 [Command("nextmessage")]
 public async Task ExampleReplyNextMessageAsync()
 {
-    var result = await Interactivity.NextMessageAsync(x => x.Author == Context.User);
+    var result = await Interactivity.NextMessageAsync(x => x.Author.Id == Context.User.Id);
 
     if (result.IsSuccess == true) {
         Interactivity.DelayedSendMessageAndDeleteAsync(


### PR DESCRIPTION
Comparing users by id is preferable to comparing by reference because dnet doesn't override the equality operators or functions.