### PR TITLE
Add troubleshooting to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ public async Task ConfirmAsync()
 
  >  A MessageReceived handler is blocking the gateway task.
 
-If you are getting this error, make sure using interactivity in commands running on the gateway task.
+If you are getting this error and you are using interactivity in commands running on the gateway task, make sure your commands are running asynchronously (eg. by using RunMode = RunMode.Async).
 
  > You are not getting any errors but all interactive calls don't yield results and time out.
 

--- a/README.md
+++ b/README.md
@@ -124,3 +124,9 @@ public async Task ConfirmAsync()
     }
 }
 ```
+
+## Troubleshooting
+
+ >  A MessageReceived handler is blocking the gateway task.
+
+If you are getting this error and you are using the `Discord.Commands` `ModuleBase` class as a base for your commands, make sure your commands are running asynchronously (eg. by using `RunMode = RunMode.Async`).

--- a/README.md
+++ b/README.md
@@ -129,4 +129,8 @@ public async Task ConfirmAsync()
 
  >  A MessageReceived handler is blocking the gateway task.
 
-If you are getting this error and you are using the `Discord.Commands` `ModuleBase` class as a base for your commands, make sure your commands are running asynchronously (eg. by using `RunMode = RunMode.Async`).
+If you are getting this error, make sure using interactivity in commands running on the gateway task.
+
+ > You are not getting any errors but all interactive calls don't yield results and time out.
+
+Make sure to use the same client for instantiating the `InteractivityService` that is also used throughout your application.


### PR DESCRIPTION
Add a section to the readme for common errors. Starting with:

 >  A MessageReceived handler is blocking the gateway task.
