### PR TITLE
Feature: Add Slash command and Message Component support.

### DIFF
--- a/InteractivityAddon/InteractivityAddon.csproj
+++ b/InteractivityAddon/InteractivityAddon.csproj
@@ -36,15 +36,16 @@
     <Optimize>false</Optimize>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Discord.Net.Core" Version="3.0.0-dev-20210617.3" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.0.0-dev-20210617.3" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Discord.Net.Labs" Version="2.4.5" />
   </ItemGroup>
 </Project>

--- a/InteractivityAddon/InteractivityAddon.csproj
+++ b/InteractivityAddon/InteractivityAddon.csproj
@@ -46,6 +46,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Labs" Version="2.4.5" />
+    <PackageReference Include="Discord.Net.Labs.Core" Version="2.4.3" />
+    <PackageReference Include="Discord.Net.Labs.WebSocket" Version="2.4.5" />
   </ItemGroup>
 </Project>

--- a/InteractivityAddon/InteractivityService.cs
+++ b/InteractivityAddon/InteractivityService.cs
@@ -291,6 +291,15 @@ namespace Interactivity
             }
         }
 
+        /// <summary>
+        /// Waits for a button or select menu to be sent that passes the <paramref name="filter"/>.
+        /// </summary>
+        /// <param name="filter">The <see cref="Criteria{SocketMessageComponent}"/> which the component has to pass.</param>
+        /// <param name="actions">The <see cref="ActionCollection{SocketMessageComponent}"/> which gets executed to incoming component.</param>
+        /// <param name="timeout">The time to wait before the methods retuns a timeout result.</param>
+        /// <param name="runOnGateway">Whether to run the internal event handlers used for interactivity in a seperate task.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel the request.</param>
+        /// <returns></returns>
         public async Task<InteractivityResult<SocketMessageComponent>> NextMessageComponentAsync(Predicate<SocketMessageComponent> filter = null, Func<SocketMessageComponent, bool, Task> actions = null,
             TimeSpan? timeout = null, bool? runOnGateway = null, CancellationToken cancellationToken = default)
         {
@@ -353,6 +362,15 @@ namespace Interactivity
             }
         }
 
+        /// <summary>
+        /// Waits for a slash command to be sent that passes the <paramref name="filter"/>.
+        /// </summary>
+        /// <param name="filter">The <see cref="Criteria{SocketSlashCommand}"/> which the command has to pass.</param>
+        /// <param name="actions">The <see cref="ActionCollection{SocketSlashCommand}"/> which gets executed to incoming slash commands.</param>
+        /// <param name="timeout">The time to wait before the methods retuns a timeout result.</param>
+        /// <param name="runOnGateway">Whether to run the internal event handlers used for interactivity in a seperate task.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to cancel the request.</param>
+        /// <returns></returns>
         public async Task<InteractivityResult<SocketSlashCommand>> NextSlashCommandAsync(Predicate<SocketSlashCommand> filter = null, Func<SocketSlashCommand, bool, Task> actions = null,
             TimeSpan? timeout = null, bool? runOnGateway = null, CancellationToken cancellationToken = default)
         {

--- a/InteractivityAddon/InteractivityService.cs
+++ b/InteractivityAddon/InteractivityService.cs
@@ -291,6 +291,130 @@ namespace Interactivity
             }
         }
 
+        public async Task<InteractivityResult<SocketMessageComponent>> NextMessageComponentAsync(Predicate<SocketMessageComponent> filter = null, Func<SocketMessageComponent, bool, Task> actions = null,
+            TimeSpan? timeout = null, bool? runOnGateway = null, CancellationToken cancellationToken = default)
+        {
+            var startTime = DateTime.UtcNow;
+
+            actions ??= ((s, v) => Task.CompletedTask);
+            filter ??= (s => true);
+
+            var componentSource = new TaskCompletionSource<InteractivityResult<SocketMessageComponent>>();
+            var cancelSource = new TaskCompletionSource<bool>();
+
+            var cancellationRegistration = cancellationToken.Register(() => cancelSource.SetResult(true));
+
+            var componentTask = componentSource.Task;
+            var cancelTask = cancelSource.Task;
+            var timeoutTask = Task.Delay(timeout ?? DefaultTimeout);
+
+            async Task CheckComponentAsync(SocketMessageComponent s)
+            {
+                if (!filter.Invoke(s))
+                {
+                    await actions.Invoke(s, true).ConfigureAwait(false);
+                    return;
+                }
+
+                await actions.Invoke(s, false).ConfigureAwait(false);
+                componentSource.SetResult(new InteractivityResult<SocketMessageComponent>(s, s.CreatedAt - startTime, false, false));
+            }
+            async Task HandleInteractionAsync(SocketInteraction interaction)
+            {
+                if(interaction is SocketMessageComponent component)
+                {
+                    if (runOnGateway ?? RunOnGateway)
+                    {
+                        await CheckComponentAsync(component);
+                    }
+                    else
+                    {
+                        _ = Task.Run(() => CheckComponentAsync(component));
+                    }
+                }
+            }
+
+            try
+            {
+                Client.InteractionCreated += HandleInteractionAsync;
+
+                var result = await Task.WhenAny(componentTask, timeoutTask, cancelTask).ConfigureAwait(false);
+
+                return result == componentTask
+                    ? await componentTask.ConfigureAwait(false)
+                    : result == timeoutTask
+                        ? new InteractivityResult<SocketMessageComponent>(default, timeout ?? DefaultTimeout, true, false)
+                        : new InteractivityResult<SocketMessageComponent>(default, DateTime.UtcNow - startTime, false, true);
+            }
+            finally
+            {
+                Client.InteractionCreated -= HandleInteractionAsync;
+                cancellationRegistration.Dispose();
+            }
+        }
+
+        public async Task<InteractivityResult<SocketSlashCommand>> NextSlashCommandAsync(Predicate<SocketSlashCommand> filter = null, Func<SocketSlashCommand, bool, Task> actions = null,
+            TimeSpan? timeout = null, bool? runOnGateway = null, CancellationToken cancellationToken = default)
+        {
+            var startTime = DateTime.UtcNow;
+
+            actions ??= ((s, v) => Task.CompletedTask);
+            filter ??= (s => true);
+
+            var commandSource = new TaskCompletionSource<InteractivityResult<SocketSlashCommand>>();
+            var cancelSource = new TaskCompletionSource<bool>();
+
+            var cancellationRegistration = cancellationToken.Register(() => cancelSource.SetResult(true));
+
+            var commandTask = commandSource.Task;
+            var cancelTask = cancelSource.Task;
+            var timeoutTask = Task.Delay(timeout ?? DefaultTimeout);
+
+            async Task CheckSlashCommandAsync(SocketSlashCommand s)
+            {
+                if (!filter.Invoke(s))
+                {
+                    await actions.Invoke(s, true).ConfigureAwait(false);
+                    return;
+                }
+
+                await actions.Invoke(s, false).ConfigureAwait(false);
+                commandSource.SetResult(new InteractivityResult<SocketSlashCommand>(s, s.CreatedAt - startTime, false, false));
+            }
+            async Task HandleInteractionAsync(SocketInteraction interaction)
+            {
+                if (interaction is SocketSlashCommand component)
+                {
+                    if (runOnGateway ?? RunOnGateway)
+                    {
+                        await CheckSlashCommandAsync(component);
+                    }
+                    else
+                    {
+                        _ = Task.Run(() => CheckSlashCommandAsync(component));
+                    }
+                }
+            }
+
+            try
+            {
+                Client.InteractionCreated += HandleInteractionAsync;
+
+                var result = await Task.WhenAny(commandTask, timeoutTask, cancelTask).ConfigureAwait(false);
+
+                return result == commandTask
+                    ? await commandTask.ConfigureAwait(false)
+                    : result == timeoutTask
+                        ? new InteractivityResult<SocketSlashCommand>(default, timeout ?? DefaultTimeout, true, false)
+                        : new InteractivityResult<SocketSlashCommand>(default, DateTime.UtcNow - startTime, false, true);
+            }
+            finally
+            {
+                Client.InteractionCreated -= HandleInteractionAsync;
+                cancellationRegistration.Dispose();
+            }
+        }
+
         /// <summary>
         /// Waits for a user/users to confirm something.
         /// </summary>


### PR DESCRIPTION
# Summary
This PR adds the [Discord.NET Labs](https://www.nuget.org/packages/Discord.Net.Labs/) package in place of dnet. This allows usage of Slash commands and Message components.

## Changes
Added `NextMessageComponentAsync` and `NextSlashCommandAsync` to the InteractivityService.

## Things to talk about
I don't have a lot of experience with this lib or its code base, but one thing that would be cool to see is button based pagination. From my quick glances at how the pagination works it seems it would not be too difficult to add.